### PR TITLE
Adds 'atlassian-python-api' package, needed by the Confluence integration

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -68,3 +68,5 @@ pytube==15.0.0
 extract_msg
 pydub
 duckduckgo-search~=6.1.7
+
+atlassian-python-api


### PR DESCRIPTION
Adds 'atlassian-python-api' package, needed by the Confluence integration